### PR TITLE
update pkgx to `2.2.1`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,9 +29,7 @@ runs:
           ${{ runner.os }}-pkgx-
 
     - name: Setup pkgx tools
-      working-directory: ${{ inputs.path }}
-      shell: bash
-      run: pkgx dev integrate
+      uses: pkgxdev/dev@v1
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - name: Install pkgx
-      uses: pkgxdev/setup@v3
+      uses: pkgxdev/setup@v
 
     - name: Generate pkgx Cache Key
       id: pkgx-cache-key
@@ -31,15 +31,7 @@ runs:
     - name: Override NodeJS
       working-directory: ${{ inputs.path }}
       shell: bash
-      run: |
-        TMP="$(mktemp)"
-        pkgx --internal.activate "$PWD" > "$TMP"
-
-        if ! node --version >/dev/null 2>&1; then
-          eval "$(pkgx +node)"
-        fi
-
-        node "$GITHUB_ACTION_PATH"/parse.js "$TMP"
+      run: eval "$(pkgx +node)"
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - name: Install pkgx
-      uses: pkgxdev/setup@v2
+      uses: pkgxdev/setup@v3
 
     - name: Generate pkgx Cache Key
       id: pkgx-cache-key

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,10 +28,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pkgx-
 
-    - name: Override NodeJS
+    - name: Setup pkgx tools
       working-directory: ${{ inputs.path }}
       shell: bash
-      run: eval "$(pkgx +node)"
+      run: pkgx dev integrate
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,23 +12,7 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Install pkgx
-      uses: pkgxdev/setup@v3
-
-    - name: Generate pkgx Cache Key
-      id: pkgx-cache-key
-      shell: bash
-      run: echo "deps_hash=$(jq -r '.pkgx.dependencies' package.json | sha256sum | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-
-    - name: Cache pkgx Tools
-      uses: actions/cache@v4
-      with:
-        path: ~/.pkgx
-        key: ${{ runner.os }}-pkgx-${{ steps.pkgx-cache-key.outputs.deps_hash }}
-        restore-keys: |
-          ${{ runner.os }}-pkgx-
-
-    - name: Setup pkgx tools
+    - name: Setup pkgx Tools
       uses: pkgxdev/dev@v1
 
     - name: Cache Go modules

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - name: Install pkgx
-      uses: pkgxdev/setup@v
+      uses: pkgxdev/setup@v3
 
     - name: Generate pkgx Cache Key
       id: pkgx-cache-key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # For building the apps/services.
-FROM pkgxdev/pkgx:v1.3.1 AS base
+FROM pkgxdev/pkgx:v2.2.1 AS base
 
 ARG APP_SERVICE
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1

--- a/Dockerfile.spa
+++ b/Dockerfile.spa
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # For building the apps/services.
-FROM pkgxdev/pkgx:v1.3.1 AS base
+FROM pkgxdev/pkgx:v2.2.1 AS base
 
 ARG APP_SERVICE
 ARG VITE_API_BASE_URL


### PR DESCRIPTION
This PR updates `pkgx` to `2.2.1` which requires you to run:

```sh
$ curl https://pkgx.sh | sh
$ pkgx pkgx^1 deintegrate && pkgx dev integrate
```